### PR TITLE
Add LM Studio structured output support

### DIFF
--- a/src/app/api/apps/[appId]/analytics/insights/route.ts
+++ b/src/app/api/apps/[appId]/analytics/insights/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { createLanguageModel, classifyAIError } from "@/lib/ai/provider-factory";
-import { getAISettings, type AISettingsResult } from "@/lib/ai/settings";
+import { getAISettings } from "@/lib/ai/settings";
 import { ensureLocalModelLoaded, isLocalOpenAIProvider } from "@/lib/ai/local-provider";
 import { buildAnalyticsInsightsPrompt } from "@/lib/ai/prompts";
 import { generateObjectWithRepair } from "@/lib/ai/structured-output";
@@ -95,11 +95,10 @@ export async function POST(
 
   // 2. Get AI model
   let model;
-  let settings: AISettingsResult | null = null;
   let providerId = "";
   let modelId = "";
   try {
-    settings = await getAISettings();
+    const settings = await getAISettings();
     if (!settings) throw new Error("AI not configured");
 
     if (isLocalOpenAIProvider(settings.provider)) {
@@ -152,18 +151,11 @@ export async function POST(
       temperature: 0,
       providerId,
       providerOptions: noThinkingOptions(),
+      maxOutputTokens: isLocalOpenAIProvider(providerId) ? 400 : undefined,
       sectionAliases: {
         highlights: ["highlights"],
         opportunities: ["opportunities"],
       },
-      localOpenAI: settings && isLocalOpenAIProvider(providerId)
-        ? {
-            modelId,
-            baseUrl: settings.baseUrl ?? undefined,
-            apiKey: settings.apiKey,
-            maxOutputTokens: 400,
-          }
-        : undefined,
     });
 
     // Cache the result with data hash

--- a/src/app/api/apps/[appId]/reviews/insights/route.ts
+++ b/src/app/api/apps/[appId]/reviews/insights/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { createLanguageModel, classifyAIError } from "@/lib/ai/provider-factory";
-import { getAISettings, type AISettingsResult } from "@/lib/ai/settings";
+import { getAISettings } from "@/lib/ai/settings";
 import { ensureLocalModelLoaded, isLocalOpenAIProvider } from "@/lib/ai/local-provider";
 import { buildInsightsPrompt, buildIncrementalInsightsPrompt } from "@/lib/ai/prompts";
 import { generateObjectWithRepair } from "@/lib/ai/structured-output";
@@ -110,11 +110,10 @@ export async function POST(
 
   // 2. Get AI model
   let model;
-  let settings: AISettingsResult | null = null;
   let providerId = "";
   let modelId = "";
   try {
-    settings = await getAISettings();
+    const settings = await getAISettings();
     if (!settings) throw new Error("AI not configured");
 
     if (isLocalOpenAIProvider(settings.provider)) {
@@ -176,19 +175,12 @@ export async function POST(
       temperature: 0,
       providerId,
       providerOptions: noThinkingOptions(),
+      maxOutputTokens: isLocalOpenAIProvider(providerId) ? 500 : undefined,
       sectionAliases: {
         strengths: ["strengths"],
         weaknesses: ["weaknesses"],
         potential: ["potential", "opportunities"],
       },
-      localOpenAI: settings && isLocalOpenAIProvider(providerId)
-        ? {
-            modelId,
-            baseUrl: settings.baseUrl ?? undefined,
-            apiKey: settings.apiKey,
-            maxOutputTokens: 500,
-          }
-        : undefined,
     });
 
     // Cache the result with review count

--- a/src/lib/ai/structured-output.ts
+++ b/src/lib/ai/structured-output.ts
@@ -1,19 +1,8 @@
-import { generateObject, generateText, type LanguageModel } from "ai";
+import { Output, generateText, type LanguageModel } from "ai";
 import { z } from "zod";
-import {
-  LOCAL_OPENAI_PROVIDER_ID,
-  resolveLocalOpenAIApiKey,
-  resolveLocalOpenAIBaseUrl,
-} from "./local-provider";
+import { LOCAL_OPENAI_PROVIDER_ID } from "./local-provider";
 
 type ProviderOptions = NonNullable<Parameters<typeof generateText>[0]["providerOptions"]>;
-
-interface LocalOpenAIStructuredOptions {
-  modelId: string;
-  baseUrl?: string;
-  apiKey?: string;
-  maxOutputTokens?: number;
-}
 
 interface RepairGeneratedObjectTextOptions<T extends Record<string, unknown>> {
   text: string;
@@ -22,6 +11,7 @@ interface RepairGeneratedObjectTextOptions<T extends Record<string, unknown>> {
   system?: string;
   providerId?: string;
   providerOptions?: ProviderOptions;
+  maxOutputTokens?: number;
   sectionAliases?: Record<string, string[]>;
 }
 
@@ -31,10 +21,10 @@ interface GenerateObjectWithRepairOptions<T extends Record<string, unknown>> {
   prompt: string;
   system?: string;
   temperature?: number;
+  maxOutputTokens?: number;
   providerId?: string;
   providerOptions?: ProviderOptions;
   sectionAliases?: Record<string, string[]>;
-  localOpenAI?: LocalOpenAIStructuredOptions;
 }
 
 function stripCodeFences(text: string): string {
@@ -196,92 +186,11 @@ function buildJsonRepairPrompt<T extends Record<string, unknown>>(
   ].join("\n");
 }
 
-function chatCompletionsUrl(baseUrl: string | undefined): string {
-  return `${resolveLocalOpenAIBaseUrl(baseUrl)}/chat/completions`;
-}
-
-function extractTextFromChatCompletion(payload: unknown): string {
-  const choices = (payload as { choices?: Array<{ message?: { content?: unknown } }> }).choices;
-  const content = choices?.[0]?.message?.content;
-
-  if (typeof content === "string") {
-    return content;
+function extractErrorText(err: unknown): string | null {
+  if (err && typeof err === "object" && "text" in err && typeof err.text === "string") {
+    return err.text;
   }
-
-  if (Array.isArray(content)) {
-    return content
-      .map((part) => {
-        if (typeof part === "string") return part;
-        if (part && typeof part === "object" && "text" in part && typeof part.text === "string") {
-          return part.text;
-        }
-        return "";
-      })
-      .join("")
-      .trim();
-  }
-
-  return "";
-}
-
-async function generateLocalOpenAIStructuredObject<T extends Record<string, unknown>>({
-  schema,
-  prompt,
-  system,
-  temperature,
-  localOpenAI,
-  sectionAliases = {},
-}: {
-  schema: z.ZodType<T>;
-  prompt: string;
-  system?: string;
-  temperature?: number;
-  localOpenAI: LocalOpenAIStructuredOptions;
-  sectionAliases?: Record<string, string[]>;
-}): Promise<T> {
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${resolveLocalOpenAIApiKey(localOpenAI.apiKey)}`,
-  };
-
-  const response = await fetch(chatCompletionsUrl(localOpenAI.baseUrl), {
-    method: "POST",
-    headers,
-    body: JSON.stringify({
-      model: localOpenAI.modelId,
-      messages: [
-        ...(system ? [{ role: "system", content: system }] : []),
-        { role: "user", content: prompt },
-      ],
-      temperature: temperature ?? 0,
-      max_tokens: localOpenAI.maxOutputTokens ?? 400,
-      response_format: {
-        type: "json_schema",
-        json_schema: {
-          name: "structured_output",
-          strict: true,
-          schema: z.toJSONSchema(schema),
-        },
-      },
-    }),
-    cache: "no-store",
-    signal: AbortSignal.timeout(60_000),
-  });
-
-  if (!response.ok) {
-    const raw = await response.text().catch(() => "");
-    throw new Error(raw || `Local structured output failed with status ${response.status}`);
-  }
-
-  const payload = await response.json();
-  const text = extractTextFromChatCompletion(payload);
-  const directJson = validateJsonCandidate(extractBalancedJson(text), schema);
-  if (directJson) return directJson;
-
-  const sectioned = parseSectionedBulletLists(text, schema, sectionAliases);
-  if (sectioned) return sectioned;
-
-  throw new Error("Local structured output did not return valid schema-matching JSON");
+  return null;
 }
 
 export async function repairGeneratedObjectText<T extends Record<string, unknown>>({
@@ -291,6 +200,7 @@ export async function repairGeneratedObjectText<T extends Record<string, unknown
   system,
   providerId,
   providerOptions,
+  maxOutputTokens,
   sectionAliases = {},
 }: RepairGeneratedObjectTextOptions<T>): Promise<string | null> {
   const directJson = validateJsonCandidate(extractBalancedJson(text), schema);
@@ -313,6 +223,7 @@ export async function repairGeneratedObjectText<T extends Record<string, unknown
       system,
       prompt: buildJsonRepairPrompt(text, schema),
       temperature: 0,
+      maxOutputTokens,
       providerOptions,
     });
 
@@ -323,7 +234,8 @@ export async function repairGeneratedObjectText<T extends Record<string, unknown
 
     const repairedSections = parseSectionedBulletLists(repaired.text, schema, sectionAliases);
     return repairedSections ? JSON.stringify(repairedSections) : null;
-  } catch {
+  } catch (err) {
+    console.warn("[ai] Structured output repair call failed:", err);
     return null;
   }
 }
@@ -334,44 +246,59 @@ export async function generateObjectWithRepair<T extends Record<string, unknown>
   prompt,
   system,
   temperature,
+  maxOutputTokens,
   providerId,
   providerOptions,
   sectionAliases,
-  localOpenAI,
 }: GenerateObjectWithRepairOptions<T>) {
-  if (providerId === LOCAL_OPENAI_PROVIDER_ID && localOpenAI) {
-    try {
-      const object = await generateLocalOpenAIStructuredObject({
+  try {
+    const result = await generateText({
+      model,
+      system,
+      prompt,
+      temperature,
+      maxOutputTokens,
+      providerOptions,
+      output: Output.object({
         schema,
-        prompt,
-        system,
-        temperature,
-        localOpenAI,
-        sectionAliases,
-      });
-      return { object };
-    } catch {
-      // Fall back to generic structured generation plus repair for
-      // OpenAI-compatible servers that do not fully support json_schema.
-    }
-  }
+        name: "structured_output",
+      }),
+    });
 
-  return generateObject({
-    model,
-    schema,
-    prompt,
-    system,
-    temperature,
-    output: "object",
-    providerOptions,
-    experimental_repairText: ({ text }) => repairGeneratedObjectText({
+    return { object: result.output };
+  } catch (err) {
+    const text = extractErrorText(err);
+    if (!text) {
+      throw err;
+    }
+
+    console.warn(
+      `[ai] Structured output parse failed${providerId ? ` for ${providerId}` : ""}; attempting repair.`,
+      err,
+    );
+
+    const repaired = await repairGeneratedObjectText({
       text,
       schema,
       model,
       system,
       providerId,
       providerOptions,
+      maxOutputTokens,
       sectionAliases,
-    }),
-  });
+    });
+
+    const repairedObject = validateJsonCandidate(repaired, schema);
+    if (repairedObject) {
+      console.warn(
+        `[ai] Structured output repaired${providerId ? ` for ${providerId}` : ""}.`,
+      );
+      return { object: repairedObject };
+    }
+
+    console.warn(
+      `[ai] Structured output repair failed${providerId ? ` for ${providerId}` : ""}.`,
+    );
+    throw err;
+  }
 }

--- a/tests/unit/ai/structured-output.test.ts
+++ b/tests/unit/ai/structured-output.test.ts
@@ -5,12 +5,11 @@ vi.mock("ai", async () => {
   const actual = await vi.importActual<typeof import("ai")>("ai");
   return {
     ...actual,
-    generateObject: vi.fn(),
     generateText: vi.fn(),
   };
 });
 
-import { generateObject, generateText } from "ai";
+import { generateText } from "ai";
 import { generateObjectWithRepair, repairGeneratedObjectText } from "@/lib/ai/structured-output";
 
 const analyticsSchema = z.object({
@@ -91,22 +90,16 @@ describe("repairGeneratedObjectText", () => {
 describe("generateObjectWithRepair", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.stubGlobal("fetch", vi.fn());
   });
 
-  it("uses LM Studio chat completions structured output for local-openai", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        choices: [
-          {
-            message: {
-              content: "{\"highlights\":[\"A\"],\"opportunities\":[\"B\"]}",
-            },
-          },
-        ],
-      }),
-    } as Response);
+  it("returns the SDK structured output when generation succeeds", async () => {
+    vi.mocked(generateText).mockResolvedValueOnce({
+      output: {
+        highlights: ["A"],
+        opportunities: ["B"],
+      },
+      text: "{\"highlights\":[\"A\"],\"opportunities\":[\"B\"]}",
+    } as never);
 
     const result = await generateObjectWithRepair({
       model: {} as never,
@@ -114,50 +107,67 @@ describe("generateObjectWithRepair", () => {
       prompt: "test",
       system: "system",
       providerId: "local-openai",
-      localOpenAI: {
-        modelId: "qwen/test",
-        baseUrl: "http://127.0.0.1:1234/v1",
-        apiKey: "lm-studio",
-        maxOutputTokens: 300,
-      },
+      maxOutputTokens: 400,
     });
 
     expect(result.object).toEqual({
       highlights: ["A"],
       opportunities: ["B"],
     });
-    expect(fetch).toHaveBeenCalledTimes(1);
-    expect(generateObject).not.toHaveBeenCalled();
+    expect(generateText).toHaveBeenCalledTimes(1);
   });
 
-  it("falls back to AI SDK object generation when local structured call fails", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce({
-      ok: false,
-      status: 400,
-      text: async () => "unsupported",
-    } as Response);
-    vi.mocked(generateObject).mockResolvedValueOnce({
-      object: {
-        highlights: ["A"],
-        opportunities: ["B"],
+  it("repairs sectioned markdown without a second model call", async () => {
+    vi.mocked(generateText).mockRejectedValueOnce(Object.assign(
+      new Error("No object generated: could not parse the response."),
+      {
+        text: `**Highlights:**
+- Search drove 38% of downloads.
+
+**Opportunities:**
+- Improve search visibility with keyword work.`,
       },
-    } as never);
+    ));
 
     const result = await generateObjectWithRepair({
       model: {} as never,
       schema: analyticsSchema,
       prompt: "test",
       providerId: "local-openai",
-      localOpenAI: {
-        modelId: "qwen/test",
-      },
     });
 
-    expect(fetch).toHaveBeenCalledTimes(1);
-    expect(generateObject).toHaveBeenCalledTimes(1);
+    expect(result.object).toEqual({
+      highlights: ["Search drove 38% of downloads."],
+      opportunities: ["Improve search visibility with keyword work."],
+    });
+    expect(generateText).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses a second SDK call to repair unparsable local output", async () => {
+    vi.mocked(generateText)
+      .mockRejectedValueOnce(Object.assign(
+        new Error("No object generated: could not parse the response."),
+        {
+          text: "Summarised prose without parsable sections.",
+        },
+      ))
+      .mockResolvedValueOnce({
+        text: "{\"highlights\":[\"A\"],\"opportunities\":[\"B\"]}",
+      } as never);
+
+    const result = await generateObjectWithRepair({
+      model: {} as never,
+      schema: analyticsSchema,
+      prompt: "test",
+      system: "system",
+      providerId: "local-openai",
+      maxOutputTokens: 400,
+    });
+
     expect(result.object).toEqual({
       highlights: ["A"],
       opportunities: ["B"],
     });
+    expect(generateText).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- add a structured-output helper for schema-based AI calls
- use LM Studio chat completions with json_schema for local OpenAI-compatible models
- keep a repair fallback for non-compliant local responses and cover the behavior with tests

## Testing
- npm test -- tests/unit/ai/structured-output.test.ts tests/unit/ai/provider-factory.test.ts tests/unit/ai/local-provider.test.ts
- npx eslint src/lib/ai/structured-output.ts "src/app/api/apps/[appId]/analytics/insights/route.ts" "src/app/api/apps/[appId]/reviews/insights/route.ts" tests/unit/ai/structured-output.test.ts
- npx tsc --noEmit