### PR TITLE
Improve dashboard and analytics i18n and formatting

### DIFF
--- a/src/app/dashboard/apps/[appId]/analytics/page.tsx
+++ b/src/app/dashboard/apps/[appId]/analytics/page.tsx
@@ -30,7 +30,7 @@ import {
 } from "@phosphor-icons/react";
 import { formatDateShort } from "@/lib/format";
 import { useAnalytics } from "@/lib/analytics-context";
-import { parseRange, filterByDateRange, previousRange, pctChange, getStoredRange } from "@/lib/analytics-range";
+import { parseRange, filterByDateRange, previousRange, getStoredRange } from "@/lib/analytics-range";
 import { KpiCard } from "@/components/kpi-card";
 import { AnalyticsStateGuard } from "@/components/analytics-state-guard";
 import { EmptyState } from "@/components/empty-state";
@@ -44,6 +44,7 @@ export default function AnalyticsOverviewPage() {
     revenueConfig,
     territoryConfig,
     funnelConfig,
+    formatPctChange,
     t,
   } = useAnalyticsLabels();
   const searchParams = useSearchParams();
@@ -143,25 +144,25 @@ export default function AnalyticsOverviewPage() {
         <KpiCard
           title={t("analytics.impressions")}
           value={totalImpressions.toLocaleString()}
-          subtitle={pctChange(totalImpressions, prevImpressions, engagement.length, prevEngagementData.length)}
+          subtitle={formatPctChange(totalImpressions, prevImpressions, engagement.length, prevEngagementData.length)}
           icon={Eye}
         />
         <KpiCard
           title={t("analytics.totalDownloads")}
           value={totalDownloads.toLocaleString()}
-          subtitle={pctChange(totalDownloads, prevDownloads, downloads.length, prevDownloadsData.length)}
+          subtitle={formatPctChange(totalDownloads, prevDownloads, downloads.length, prevDownloadsData.length)}
           icon={DownloadSimple}
         />
         <KpiCard
           title={t("analytics.proceeds")}
           value={`$${totalRevenue.toLocaleString()}`}
-          subtitle={pctChange(totalRevenue, prevRevenue, revenue.length, prevRevenueData.length)}
+          subtitle={formatPctChange(totalRevenue, prevRevenue, revenue.length, prevRevenueData.length)}
           icon={CurrencyDollar}
         />
         <KpiCard
           title={t("analytics.firstTimeDownloads")}
           value={totalFirstTime.toLocaleString()}
-          subtitle={pctChange(totalFirstTime, prevFirstTime, downloads.length, prevDownloadsData.length)}
+          subtitle={formatPctChange(totalFirstTime, prevFirstTime, downloads.length, prevDownloadsData.length)}
           icon={Timer}
         />
       </div>

--- a/src/app/dashboard/apps/[appId]/analytics/usage/page.tsx
+++ b/src/app/dashboard/apps/[appId]/analytics/usage/page.tsx
@@ -24,7 +24,7 @@ import {
   ChartLegendContent,
   type ChartConfig,
 } from "@/components/ui/chart";
-import { formatDateShort, formatDuration } from "@/lib/format";
+import { formatDateShort, formatDuration, formatVersionSessionLabel } from "@/lib/format";
 import { useAnalytics } from "@/lib/analytics-context";
 import { parseRange, filterByDateRange, getStoredRange } from "@/lib/analytics-range";
 import { AnalyticsStateGuard } from "@/components/analytics-state-guard";
@@ -89,7 +89,7 @@ export default function UsagePage() {
     for (let i = 0; i < versionKeys.length; i++) {
       const key = versionKeys[i];
       config[key] = {
-        label: key.startsWith("v") ? `v${key.slice(1).replace(/(\d)(?=\d)/g, "$1.")}` : key,
+        label: formatVersionSessionLabel(key),
         color: VERSION_COLORS[i % VERSION_COLORS.length],
       };
     }
@@ -251,7 +251,6 @@ export default function UsagePage() {
                     />
                   }
                 />
-                <ChartLegend content={<ChartLegendContent />} />
                 {versionKeys.map((key) => (
                   <Area
                     key={key}
@@ -269,6 +268,17 @@ export default function UsagePage() {
                 })}
               </AreaChart>
             </ChartContainer>
+            <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 pt-3">
+              {versionKeys.map((key) => (
+                <div key={key} className="flex items-center gap-1.5 text-xs">
+                  <div
+                    className="h-2 w-2 shrink-0 rounded-[2px]"
+                    style={{ backgroundColor: versionConfig[key]?.color }}
+                  />
+                  <span>{versionConfig[key]?.label}</span>
+                </div>
+              ))}
+            </div>
           </CardContent>
         </Card>
       )}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -560,6 +560,7 @@ function pickPendingVersions(versions: AscVersion[]): AscVersion[] {
 }
 
 function AppCardStats({ data }: { data: AnalyticsData }) {
+  const t = useTranslations();
   const downloads = data.dailyDownloads.reduce(
     (sum, d) => sum + d.firstTime + d.redownload,
     0,
@@ -585,16 +586,16 @@ function AppCardStats({ data }: { data: AnalyticsData }) {
   return (
     <div className="grid grid-cols-3 gap-3 text-xs tabular-nums">
       <div>
-        <p className="text-muted-foreground">Downloads</p>
+        <p className="text-muted-foreground">{t("dashboard.downloads")}</p>
         <p className="font-medium">{downloads.toLocaleString()}</p>
       </div>
       <div>
-        <p className="text-muted-foreground">Proceeds</p>
+        <p className="text-muted-foreground">{t("dashboard.proceeds")}</p>
         <p className="font-medium">${proceeds.toLocaleString(undefined, { maximumFractionDigits: 0 })}</p>
       </div>
       {crashFree && (
         <div>
-          <p className="text-muted-foreground">Crash-free</p>
+          <p className="text-muted-foreground">{t("dashboard.crashFree")}</p>
           <p className="font-medium">{crashFree}%</p>
         </div>
       )}

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -272,7 +272,7 @@ function ChartLegendContent({
   return (
     <div
       className={cn(
-        "flex items-center justify-center gap-4",
+        "flex w-full flex-wrap items-center justify-center gap-x-4 gap-y-1.5",
         verticalAlign === "top" ? "pb-3" : "pt-3",
         className
       )}

--- a/src/lib/analytics-range.ts
+++ b/src/lib/analytics-range.ts
@@ -130,12 +130,16 @@ export function pctChange(
   previous: number,
   currentDays: number,
   previousDays: number,
+  formatLabel?: (pct: string) => string,
 ): string | null {
   if (previous === 0) return null;
   if (previousDays < currentDays * 0.5) return null;
   const pct = ((current - previous) / previous) * 100;
   const sign = pct >= 0 ? "+" : "";
-  return `${sign}${pct.toFixed(1)}% from previous period`;
+  const pctStr = `${sign}${pct.toFixed(1)}%`;
+  return formatLabel
+    ? formatLabel(pctStr)
+    : `${pctStr} from previous period`;
 }
 
 export function filterByDateRange<T extends { date: string }>(

--- a/src/lib/asc/analytics-aggregation.ts
+++ b/src/lib/asc/analytics-aggregation.ts
@@ -1,4 +1,5 @@
 import type { AnalyticsData } from "./analytics-types";
+import { encodeVersionSessionKey } from "@/lib/format";
 
 // ---------- Generic helpers ----------
 
@@ -234,8 +235,7 @@ export function aggregateVersionSessions(
     .map(([date, versions]) => {
       const entry: Record<string, number | string> = { date };
       for (const [version, count] of versions) {
-        // Convert version string to a safe key (e.g., "1.2.0" -> "v1.2.0")
-        entry[`v${version.replace(/\./g, "")}`] = count;
+        entry[encodeVersionSessionKey(version)] = count;
       }
       return entry;
     }) as AnalyticsData["dailyVersionSessions"];

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -160,9 +160,9 @@ function makeDemoAnalytics(appIndex: number) {
 
   const dailyVersionSessions = generateDailyData(30, (date, i) => ({
     date,
-    v230: noisyValue(rng, base * 2, base * 0.7, i),
-    v220: noisyValue(rng, Math.max(10, base * 1.5 - i * 3), base * 0.4, i),
-    v210: noisyValue(rng, Math.max(0, base * 0.6 - i * 2), base * 0.2, i),
+    v2_3_0: noisyValue(rng, base * 2, base * 0.7, i),
+    v2_2_0: noisyValue(rng, Math.max(10, base * 1.5 - i * 3), base * 0.4, i),
+    v2_1_0: noisyValue(rng, Math.max(0, base * 0.6 - i * 2), base * 0.2, i),
   }));
 
   const dailyOptIn = generateDailyData(30, (date, i) => ({

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -77,6 +77,17 @@ export function formatDuration(seconds: number, compact = false): string {
   return m > 0 ? `${h}h ${m}m` : `${h}h`;
 }
 
+/** Encode an app version for use as a chart data key (dots are not CSS-safe). */
+export function encodeVersionSessionKey(version: string): string {
+  return `v${version.replace(/\./g, "_")}`;
+}
+
+/** Format an encoded version key for display (e.g. v1_18_0 → v1.18.0). */
+export function formatVersionSessionLabel(key: string): string {
+  if (!key.startsWith("v")) return key;
+  return `v${key.slice(1).replace(/_/g, ".")}`;
+}
+
 /** Check if a string is a valid HTTP(S) URL. Empty strings return true (optional fields). */
 export function isValidUrl(s: string): boolean {
   if (!s) return true;

--- a/src/lib/i18n/locales/de.ts
+++ b/src/lib/i18n/locales/de.ts
@@ -1099,6 +1099,7 @@ export const de: Messages = {
   analyticsRange: {
     lastDay: "Letzter Tag",
     lastDays: "Letzte {days} Tage",
+    pctFromPreviousPeriod: "{pct} gegenüber dem vorherigen Zeitraum",
     month: "Monat",
     customRange: "Eigener Zeitraum…",
   },

--- a/src/lib/i18n/locales/de.ts
+++ b/src/lib/i18n/locales/de.ts
@@ -194,6 +194,8 @@ export const de: Messages = {
     fetchingAnalytics: "Analysedaten werden abgerufen – beim ersten Laden kann das einen Moment dauern",
     noAnalyticsData: "Noch keine Analysedaten verfügbar.",
     proceeds: "Erlöse",
+    downloads: "Downloads",
+    crashFree: "Absturzfrei",
     noDataForRange: "Keine Daten für diesen Zeitraum.",
     awaitingData: "Warten auf Daten von App Store Connect",
     pending: "Ausstehend",

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -192,6 +192,8 @@ export const en = {
     fetchingAnalytics: "Fetching analytics data – this may take a moment on first load",
     noAnalyticsData: "No analytics data available yet.",
     proceeds: "Proceeds",
+    downloads: "Downloads",
+    crashFree: "Crash-free",
     noDataForRange: "No data for this date range.",
     awaitingData: "Awaiting data from App Store Connect",
     pending: "Pending",

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -1097,6 +1097,7 @@ export const en = {
   analyticsRange: {
     lastDay: "Last day",
     lastDays: "Last {days} days",
+    pctFromPreviousPeriod: "{pct} from previous period",
     month: "Month",
     customRange: "Custom range…",
   },

--- a/src/lib/i18n/locales/fr.ts
+++ b/src/lib/i18n/locales/fr.ts
@@ -1099,6 +1099,7 @@ export const fr: Messages = {
   analyticsRange: {
     lastDay: "Dernier jour",
     lastDays: "{days} derniers jours",
+    pctFromPreviousPeriod: "{pct} par rapport à la période précédente",
     month: "Mois",
     customRange: "Plage personnalisée…",
   },

--- a/src/lib/i18n/locales/fr.ts
+++ b/src/lib/i18n/locales/fr.ts
@@ -194,6 +194,8 @@ export const fr: Messages = {
     fetchingAnalytics: "Récupération des données analytiques – cela peut prendre un moment au premier chargement",
     noAnalyticsData: "Aucune donnée analytique disponible pour le moment.",
     proceeds: "Recettes",
+    downloads: "Téléchargements",
+    crashFree: "Sans plantage",
     noDataForRange: "Aucune donnée pour cette plage de dates.",
     awaitingData: "En attente de données d’App Store Connect",
     pending: "En attente",

--- a/src/lib/i18n/locales/ru.ts
+++ b/src/lib/i18n/locales/ru.ts
@@ -194,6 +194,8 @@ export const ru: Messages = {
     fetchingAnalytics: "Получение аналитики – при первой загрузке это может занять время",
     noAnalyticsData: "Данные аналитики пока недоступны.",
     proceeds: "Выручка",
+    downloads: "Загрузки",
+    crashFree: "Без сбоев",
     noDataForRange: "Нет данных за этот период.",
     awaitingData: "Ожидание данных от App Store Connect",
     pending: "Ожидается",

--- a/src/lib/i18n/locales/ru.ts
+++ b/src/lib/i18n/locales/ru.ts
@@ -1099,6 +1099,7 @@ export const ru: Messages = {
   analyticsRange: {
     lastDay: "Последний день",
     lastDays: "Последние {days} дней",
+    pctFromPreviousPeriod: "{pct} по сравнению с предыдущим периодом",
     month: "Месяц",
     customRange: "Свой период…",
   },

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -193,6 +193,8 @@ export const zhCN: Messages = {
     fetchingAnalytics: "正在获取分析数据 – 首次加载可能需要一些时间",
     noAnalyticsData: "暂无分析数据。",
     proceeds: "收入",
+    downloads: "下载量",
+    crashFree: "无崩溃",
     noDataForRange: "该日期范围内无数据。",
     awaitingData: "等待 App Store Connect 数据",
     pending: "处理中",

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -1093,6 +1093,7 @@ export const zhCN: Messages = {
   analyticsRange: {
     lastDay: "最近一天",
     lastDays: "最近 {days} 天",
+    pctFromPreviousPeriod: "较上一周期 {pct}",
     month: "月份",
     customRange: "自定义范围…",
   },

--- a/src/lib/i18n/use-analytics-labels.ts
+++ b/src/lib/i18n/use-analytics-labels.ts
@@ -1,7 +1,8 @@
 "use client";
 
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import type { ChartConfig } from "@/components/ui/chart";
+import { pctChange } from "@/lib/analytics-range";
 import { useTranslations } from "./locale-context";
 
 /** Translated analytics chart configs, KPI labels, and section titles. */
@@ -109,6 +110,14 @@ export function useAnalyticsLabels() {
     [t],
   );
 
+  const formatPctChange = useCallback(
+    (current: number, previous: number, currentDays: number, previousDays: number) =>
+      pctChange(current, previous, currentDays, previousDays, (pct) =>
+        t("analyticsRange.pctFromPreviousPeriod", { pct }),
+      ),
+    [t],
+  );
+
   return {
     downloadsConfig,
     revenueConfig,
@@ -122,6 +131,7 @@ export function useAnalyticsLabels() {
     durationConfig,
     installDeleteConfig,
     optInConfig,
+    formatPctChange,
     t,
   };
 }

--- a/tests/unit/asc/analytics.test.ts
+++ b/tests/unit/asc/analytics.test.ts
@@ -573,8 +573,8 @@ describe("buildAnalyticsData – full pipeline", () => {
     expect(result.dailyVersionSessions).toHaveLength(1);
     expect(result.dailyVersionSessions[0]).toEqual({
       date: "2026-02-01",
-      v100: 100,
-      v200: 200,
+      v1_0_0: 100,
+      v2_0_0: 200,
     });
 
     // Opt-in
@@ -1653,6 +1653,7 @@ describe("aggregation output shapes", () => {
       ["Date", "App Version", "Sessions"],
       [
         ["2026-02-01", "1.2.3", "50"],
+        ["2026-02-01", "1.18.0", "75"],
         ["2026-02-01", "2.0.0", "100"],
       ],
     );
@@ -1681,9 +1682,10 @@ describe("aggregation output shapes", () => {
     expect(result.dailyVersionSessions).toHaveLength(1);
     const entry = result.dailyVersionSessions[0];
     expect(entry.date).toBe("2026-02-01");
-    // "1.2.3" → "v123", "2.0.0" → "v200"
-    expect(entry["v123"]).toBe(50);
-    expect(entry["v200"]).toBe(100);
+    // "1.2.3" → "v1_2_3", "1.18.0" → "v1_18_0", "2.0.0" → "v2_0_0"
+    expect(entry["v1_2_3"]).toBe(50);
+    expect(entry["v1_18_0"]).toBe(75);
+    expect(entry["v2_0_0"]).toBe(100);
   });
 
   it("aggregateDownloadsBySource excludes updates", async () => {
@@ -2465,11 +2467,11 @@ describe("aggregateVersionSessions – missing date or version", () => {
     expect(result.dailyVersionSessions).toHaveLength(2);
     expect(result.dailyVersionSessions[0]).toEqual({
       date: "2026-02-01",
-      v100: 50,
+      v1_0_0: 50,
     });
     expect(result.dailyVersionSessions[1]).toEqual({
       date: "2026-02-02",
-      v100: 80,
+      v1_0_0: 80,
     });
   });
 });
@@ -2779,7 +2781,7 @@ describe("aggregation with empty/missing field values (|| fallback branches)", (
     expect(result.dailyVersionSessions).toHaveLength(1);
     expect(result.dailyVersionSessions[0]).toEqual({
       date: "2026-02-01",
-      v100: 0,
+      v1_0_0: 0,
     });
 
     // aggregateCrashesByVersion: empty App Version → `|| "Unknown"` fallback,

--- a/tests/unit/format.test.ts
+++ b/tests/unit/format.test.ts
@@ -5,6 +5,8 @@ import {
   formatDateTime,
   formatDateTimeLong,
   formatDuration,
+  encodeVersionSessionKey,
+  formatVersionSessionLabel,
   isValidUrl,
 } from "@/lib/format";
 
@@ -82,6 +84,24 @@ describe("format", () => {
 
     it("formats exact hours compact", () => {
       expect(formatDuration(3600, true)).toBe("1h");
+    });
+  });
+
+  describe("encodeVersionSessionKey", () => {
+    it("replaces dots with underscores for CSS-safe chart keys", () => {
+      expect(encodeVersionSessionKey("1.18.0")).toBe("v1_18_0");
+      expect(encodeVersionSessionKey("1.2.3")).toBe("v1_2_3");
+    });
+  });
+
+  describe("formatVersionSessionLabel", () => {
+    it("restores the original version string for display", () => {
+      expect(formatVersionSessionLabel("v1_18_0")).toBe("v1.18.0");
+      expect(formatVersionSessionLabel("v1_2_3")).toBe("v1.2.3");
+    });
+
+    it("returns non-version keys unchanged", () => {
+      expect(formatVersionSessionLabel("sessions")).toBe("sessions");
     });
   });
 


### PR DESCRIPTION
- Localize dashboard app card statistics (Downloads, Proceeds, Crash-free) across en, de, fr, ru, and zh-CN.
- Add version session key encoding and display helpers (`encodeVersionSessionKey`, `formatVersionSessionLabel`) so analytics charts show readable version labels (e.g. `v1.18.0`) while using CSS-safe data keys internally.
- Refactor analytics KPI percentage change subtitles to use a localized `formatPctChange` helper, replacing hardcoded English strings with `analyticsRange.pctFromPreviousPeriod` translations.
- Improve chart legend layout and update demo data and unit tests to match the new formatting behaviour.
<img width="1733" height="1166" alt="iShot_2026-07-04_17 40 09" src="https://github.com/user-attachments/assets/60dbedc0-3557-4022-b342-e2b305c70978" />
